### PR TITLE
Correctly include surface area in angular grid weights

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -97,7 +97,7 @@ program main_driver
 
    call sasa%get_surface(mol%id, mol%xyz, surface, dsdr)
 
-   call ascii_surface_area(output_unit, mol, surface)
+   call ascii_surface_area(output_unit, mol, surface, rad(mol%id)+config%probe)
 
    if (allocated(config%solvent)) then
       call init_smd(param,config%solvent)

--- a/src/numsa/output.f90
+++ b/src/numsa/output.f90
@@ -18,6 +18,7 @@
 module numsa_output
    use mctc_env, only : wp
    use mctc_io, only : structure_type
+   use mctc_io_constants, only : pi
    use mctc_io_convert, only : autoaa
    implicit none
    private
@@ -26,30 +27,33 @@ module numsa_output
 
 contains
 
-subroutine ascii_surface_area(unit, mol, surface)
+subroutine ascii_surface_area(unit, mol, surface, rad)
    !> Unit for output
    integer, intent(in) :: unit
    !> Molecular structure data
    class(structure_type), intent(in) :: mol
    !> Surface area for each atom
    real(wp), intent(in) :: surface(:)
+   !> Actual radii
+   real(wp), intent(in) :: rad(:)
 
    integer :: iat, isp
 
    write(unit, '(a)')
    write(unit, '(a,":")') "Surface area in Å²"
-   write(unit, '(28("-"))')
-   write(unit, '(a6,1x,a4,5x,*(1x,a10))') "#", "Z", "area"
-   write(unit, '(28("-"))')
+   write(unit, '(50("-"))')
+   write(unit, '(a6,1x,a4,5x,*(1x,a10))') "#", "Z", "area", "rad", "SASA/%"
+   write(unit, '(50("-"))')
    do iat = 1, mol%nat
       isp = mol%id(iat)
       write(unit, '(i6,1x,i4,1x,a4,*(1x,f10.4))') &
-         & iat, mol%num(isp), mol%sym(isp), surface(iat) * autoaa**2
+         & iat, mol%num(isp), mol%sym(isp), surface(iat) * autoaa**2, &
+         & rad(iat) * autoaa, surface(iat) / (4*pi*rad(iat)*rad(iat)) * 100
    end do
-   write(unit, '(28("-"))')
+   write(unit, '(50("-"))')
    write(unit, '(1x, a, t15, f13.4)') &
       "total",  sum(surface) * autoaa**2
-   write(unit, '(28("-"))')
+   write(unit, '(50("-"))')
 
 end subroutine ascii_surface_area
 

--- a/src/numsa/surface.f90
+++ b/src/numsa/surface.f90
@@ -17,6 +17,7 @@
 !> Integration of surface area
 module numsa_surface
    use mctc_env, only : wp
+   use mctc_io_constants, only : pi
    use mctc_io_convert, only : aatoau
    use numsa_search, only : list_bisection
    use numsa_lebedev, only : get_angular_grid, grid_size
@@ -140,6 +141,7 @@ subroutine new_surface_integrator(self, num, rad, probe, nang, offset, smoothing
    allocate(self%ang_grid(3, grid_size(iang)))
    allocate(self%ang_weight(grid_size(iang)))
    call get_angular_grid(iang, self%ang_grid, self%ang_weight, ierr)
+   self%ang_weight(:) = self%ang_weight * 4*pi
 
 end subroutine new_surface_integrator
 

--- a/test/test_cds.f90
+++ b/test/test_cds.f90
@@ -61,8 +61,8 @@ subroutine test_mb01(error)
    real(wp) :: cds
    real(wp), parameter :: probe = 1.4_wp * aatoau
    integer, parameter :: nang = 110
-   real(wp), parameter :: ref_h2o = 5.584952777575E+2_wp
-   real(wp), parameter :: ref_methanol = 8.657039408118E+2_wp
+   real(wp), parameter :: ref_h2o = 7.01825864667078E+3_wp
+   real(wp), parameter :: ref_methanol = 1.08787565625528E+4_wp
    call get_structure(mol, "MB16-43", "01")
 
    allocate(surface(mol%nat), dsdr(3, mol%nat, mol%nat))
@@ -100,8 +100,8 @@ subroutine test_mb02(error)
    real(wp) :: cds
    real(wp), parameter :: probe = 1.2_wp * aatoau
    integer, parameter :: nang = 230
-   real(wp), parameter :: ref_h2o = 2.851126949863E+2_wp
-   real(wp), parameter :: ref_dmso = 1.246936123208E+3_wp
+   real(wp), parameter :: ref_h2o = 3.58283179205683E+3_wp
+   real(wp), parameter :: ref_dmso = 1.56694614566661E+4_wp
    call get_structure(mol, "MB16-43", "02")
 
    allocate(surface(mol%nat), dsdr(3, mol%nat, mol%nat))
@@ -140,8 +140,8 @@ subroutine test_mb03(error)
    real(wp), parameter :: probe = 0.2_wp * aatoau
    integer, parameter :: nang = 111
       
-   real(wp), parameter :: ref_h2o = 1.468455218016E+2_wp 
-   real(wp), parameter :: ref_acetonitrile = 2.416615146404E+2_wp 
+   real(wp), parameter :: ref_h2o = 1.84531525001789E+3_wp
+   real(wp), parameter :: ref_acetonitrile = 3.03680815619881E+3_wp
    call get_structure(mol, "MB16-43", "02")
 
    allocate(surface(mol%nat), dsdr(3, mol%nat, mol%nat))

--- a/test/test_surface.f90
+++ b/test/test_surface.f90
@@ -19,6 +19,7 @@ module test_surface
    use mctc_env_testing, only : new_unittest, unittest_type, error_type, check, &
       & test_failed
    use mctc_io, only : structure_type
+   use mctc_io_constants, only : pi
    use mctc_io_convert, only : aatoau
    use mstore, only : get_structure
    use numsa
@@ -57,7 +58,7 @@ subroutine test_mb01(error)
    real(wp), allocatable :: rad(:), surface(:), dsdr(:, :, :)
    real(wp), parameter :: probe = 1.4_wp * aatoau
    integer, parameter :: nang = 110
-   real(wp), parameter :: ref(16) = [&
+   real(wp), parameter :: ref(16) = 4*pi * [&
       & 1.57762257884252E+1_wp, 7.44023682724103E+0_wp, 5.78326352983607E+0_wp, &
       & 2.96273887964889E+0_wp, 7.96228449837119E+0_wp, 6.94475560013532E+0_wp, &
       & 1.39709090557345E+0_wp, 4.61011360744476E+0_wp, 7.81217049844597E-4_wp, &
@@ -90,7 +91,7 @@ subroutine test_mb02(error)
    real(wp), allocatable :: rad(:), surface(:), dsdr(:, :, :)
    real(wp), parameter :: probe = 1.2_wp * aatoau
    integer, parameter :: nang = 230
-   real(wp), parameter :: ref(16) = [&
+   real(wp), parameter :: ref(16) = 4*pi * [&
       & 2.27659153452265E+0_wp, 5.97577009756815E+0_wp, 6.41298531564733E+0_wp, &
       & 6.55734382952262E+0_wp, 5.15770714137722E+0_wp, 1.57234609721010E+0_wp, &
       & 3.90432810917537E+0_wp, 4.21140518928471E+0_wp, 7.27814416367210E+0_wp, &
@@ -123,7 +124,7 @@ subroutine test_mb03(error)
    real(wp), allocatable :: rad(:), surface(:), dsdr(:, :, :)
    real(wp), parameter :: probe = 0.2_wp * aatoau
    integer, parameter :: nang = 111
-   real(wp), parameter :: ref(16) = [&
+   real(wp), parameter :: ref(16) = 4*pi * [&
       & 3.92672838745645E+0_wp, 4.31618518252200E+0_wp, 2.05344924554658E+0_wp, &
       & 2.60133065338031E+0_wp, 1.01849685835522E+0_wp, 7.52651997890806E+0_wp, &
       & 2.73374455863003E+0_wp, 2.19905522537305E+0_wp, 2.18761474083904E+0_wp, &


### PR DESCRIPTION
Note: `xtb` includes factor 4π in surface tension rather than the surface area. This patch includes the factor correctly in the integration of the surface area.